### PR TITLE
[FIX]exclude extra source

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -32,6 +32,7 @@ t/Foo.pm
 t/Foo/Artist.pm
 t/Foo/CD.pm
 t/Foo/ViewAll.pm
+t/Foo/Record.pm
 t/Tools.pm
 xt/97_podspell.t
 xt/98_perlcritic.t

--- a/lib/Test/Fixture/DBIC/Schema.pm
+++ b/lib/Test/Fixture/DBIC/Schema.pm
@@ -65,6 +65,7 @@ sub _delete_all {
 
     $schema->resultset($_)->delete for
         grep { $schema->source_registrations->{$_}->isa('DBIx::Class::ResultSource::Table') }
+        grep { not ref($schema->source_registrations->{$_}->name) }
             $schema->sources;
 }
 

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -6,7 +6,7 @@ use Test::Fixture::DBIC::Schema;
 use File::Temp qw/tempfile/;
 use Test::Requires 'DBD::SQLite';
 
-plan tests => 17;
+plan tests => 35;
 
 schema->storage->dbh->do(
     q{
@@ -37,6 +37,16 @@ my @fixture_sources = (
             schema => 'Artist',
             name   => 'artist',
         },
+        {
+            data => {
+                recordid => 11,
+                artist   => 11,
+                title    => 'record',
+                year     => 2019,
+            },
+            schema => 'Record',
+            name   => 'record',
+        },
     ]
 );
 
@@ -49,10 +59,26 @@ for my $fixture_src (@fixture_sources) {
     is schema->resultset('Artist')->count, 1;
     is schema->resultset('CD')->count, 1;
     is schema->resultset('ViewAll')->count, 1;
+    is schema->resultset('Record')->count, 1;
+    is schema->resultset('Karaoke')->count, 2;
     ok $fixture->{cd}, 'has key';
     ok $fixture->{artist}, 'has key';
+    ok $fixture->{record}, 'has key';
     is $fixture->{cd}->id, 3;
     is $fixture->{cd}->title, 'foo';
     is $fixture->{artist}->name, 'beatles';
+    is $fixture->{record}->id, 11;
+    is $fixture->{record}->title, 'record';
+    my @karaoke_list = schema->resultset('Karaoke')->search(
+        {},
+        {
+            select => [qw/id artist title year/],
+            as     => [qw/id artist title year/],
+            order_by => 'id'
+        }
+    )->all;
+    is $karaoke_list[0]->get_column('id'), 3;
+    is $karaoke_list[0]->get_column('title'), 'foo';
+    is $karaoke_list[1]->get_column('id'), 11;
+    is $karaoke_list[1]->get_column('title'), 'record';
 }
-

--- a/t/Foo/Record.pm
+++ b/t/Foo/Record.pm
@@ -1,0 +1,37 @@
+package t::Foo::Record;
+use strict;
+use warnings;
+use base qw/DBIx::Class/;
+
+__PACKAGE__->load_components(qw/PK::Auto Core/);
+__PACKAGE__->table('record');
+__PACKAGE__->add_columns(qw/ recordid artist title year /);
+__PACKAGE__->set_primary_key('recordid');
+
+my $source = __PACKAGE__->result_source_instance();
+my $new_source = $source->new( $source );
+$new_source->source_name( 'Karaoke' );
+
+$new_source->name( \<<SQL );
+(
+    SELECT
+        record.recordid id,
+        record.artist artist,
+        record.title title,
+        record.year year
+    FROM
+        record
+    UNION ALL
+    SELECT
+        cd.cdid id,
+        cd.artist artist,
+        cd.title title,
+        cd.year year
+    FROM
+        cd
+)
+SQL
+
+DBIx::Class::Schema->register_extra_source( 'Karaoke' => $new_source );
+
+1;

--- a/t/Tools.pm
+++ b/t/Tools.pm
@@ -34,6 +34,16 @@ $schema->storage->dbh->do(
             where cd.artist=a.artistid;
     }
 );
+$schema->storage->dbh->do(
+    q{
+        CREATE TABLE record (
+            recordid INTEGER,
+            artist   INTEGER,
+            title    VARCHAR(255),
+            year     INTEGER
+        );
+    }
+);
 
 sub import {
     my $pkg = caller(0);

--- a/t/fixture.yaml
+++ b/t/fixture.yaml
@@ -11,3 +11,10 @@
     name: beatles
   name: artist
   schema: Artist
+- data:
+    recordid: 11
+    artist: 11
+    title: record
+    year: 2019
+  name: record
+  schema: Record


### PR DESCRIPTION
When Arbitrary SQL is used (like UNION) in the `name` part when adding a new `source` of `DBIx::Class::Schema`,
I get an error with `Test::Fixture::DBIC::Schema ::_delete_all`.
So Exclude the `source` added.

- Cause
Arbitrary SQL is applied to the `FROM` clause, resulting in syntax error.
```
DBIx::Class::Storage::DBI::_prepare_sth(): DBI Exception: DBD::SQLite::db prepare_cached failed: near "(": syntax error [for Statement "DELETE FROM (
    SELECT
        record.recordid id,
        record.artist artist,
        record.title title,
        record.year year
    FROM
        record
    UNION ALL
    SELECT
        cd.cdid id,
        cd.artist artist,
        cd.title title,
        cd.year year
    FROM
        cd
)
 WHERE ( recordid IN ( SELECT me.recordid FROM (
    SELECT
        record.recordid id,
        record.artist artist,
        record.title title,
        record.year year
    FROM
        record
    UNION ALL
    SELECT
        cd.cdid id,
        cd.artist artist,
        cd.title title,
        cd.year year
    FROM
        cd
)
 me ) )"] at /Path/Test/Fixture/DBIC/Schema.pm line 66
```

- to Fix
When using Arbitrary SQL, it becomes `scalar ref` type (usually` scalar` type), 
So exclude `scalar ref` types from delete target.
```perl
sub _delete_all {
    my $schema = shift;

    $schema->resultset($_)->delete for
        grep { $schema->source_registrations->{$_}->isa('DBIx::Class::ResultSource::Table') }
        grep { not ref($schema->source_registrations->{$_}->name) }
            $schema->sources;
}
```
